### PR TITLE
Fix network selection bug in Agent

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -107,7 +107,7 @@ class Agent():
         # Q values for best actions in next_state
         # from current Q network
         
-        if self.network == "double" or "duel":
+        if self.network in ["double", "duel"]:
             Q_L = self.qnetwork_local(next_states).detach()
             _, actions_prime = Q_L.max(1)
 


### PR DESCRIPTION
## Summary
- fix logic for network selection in `Agent.learn`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6841d29113a083239b0c206c39e869b6